### PR TITLE
Use rsquo for quotes following a period

### DIFF
--- a/ext/redcarpet/html_smartypants.c
+++ b/ext/redcarpet/html_smartypants.c
@@ -149,6 +149,12 @@ smartypants_squote(struct buf *ob, struct smartypants_data *smrt, uint8_t previo
 				return next_squote_len;
 		}
 
+		// U.S.'s
+		if (t1 == 's' && previous_char == '.') {
+			BUFPUTSL(ob, "&rsquo;");
+			return 0;
+		}
+
 		if (smartypants_quotes(ob, previous_char, size > 0 ? text[1] : 0, 's', &smrt->in_squote))
 			return 0;
 

--- a/test/smarty_pants_test.rb
+++ b/test/smarty_pants_test.rb
@@ -60,4 +60,9 @@ class SmartyPantsTest < Redcarpet::TestCase
     rd = @pants.render(%(<p>501(c)</p>))
     assert_equal %(<p>501(c)</p>), rd
   end
+
+  def test_that_smart_gives_period_prefix_a_rsquo
+    markdown = @pants.render("the U.S.'s war crimes are numerous")
+    assert_equal "the U.S.&rsquo;s war crimes are numerous", markdown
+  end
 end


### PR DESCRIPTION
Markdown like "U.S.'s" is being converted to "U.S.&lsquo;s", but we want it to be "U.S.&rsquo;s".